### PR TITLE
add nd concatenation

### DIFF
--- a/arraylib/__init__.py
+++ b/arraylib/__init__.py
@@ -22,11 +22,12 @@ from arraylib.core import (
     reduce_max,
     reduce_sum,
     reduce_min,
-    move_axis,
+    move_dim,
     reduce,
     apply,
     where,
     from_numpy,
+    cat,
 )
 from arraylib.arraytypes import NDArray, JVPNDArray
 import arraylib.impl as impl
@@ -63,8 +64,9 @@ __all__ = [
     "reduce_max",
     "reduce_sum",
     "reduce_min",
-    "move_axis",
+    "move_dim",
     "reduce",
     "apply",
     "where",
+    "cat",
 ]

--- a/arraylib/impl.py
+++ b/arraylib/impl.py
@@ -52,9 +52,11 @@ def _(lhs, rhs) -> NDArray:
 def _(lhs, rhs) -> NDArray:
     return core.mul(rhs, lhs)
 
+
 @primitive.div_p.register(NDArray, float)
 def _(lhs, rhs) -> NDArray:
     return NDArray(buffer=lib.array_scalar_div(lhs.buffer, rhs))
+
 
 @primitive.div_p.register(NDArray, NDArray)
 def _(lhs, rhs) -> NDArray:
@@ -120,11 +122,11 @@ def _(array) -> NDArray:
     return NDArray(buffer=lib.array_ravel(array.buffer))
 
 
-@primitive.move_axis_p.register(NDArray)
+@primitive.move_dim_p.register(NDArray)
 def _(array, src: tuple[int, ...], dst: tuple[int, ...]) -> NDArray:
     src = ffi.new("size_t[]", src)
     dst = ffi.new("size_t[]", dst)
-    return NDArray(buffer=lib.array_move_axis(array.buffer, src, dst, len(src)))
+    return NDArray(buffer=lib.array_move_dim(array.buffer, src, dst, len(src)))
 
 
 # comparison operations
@@ -323,6 +325,7 @@ def _(cond, lhs, rhs):
     rhs = rhs.buffer
     return NDArray(buffer=lib.array_array_array_where(cond, lhs, rhs))
 
+
 @primitive.where_p.register(NDArray, float)
 def _(cond, lhs, rhs):
     cond = cond.buffer
@@ -335,3 +338,13 @@ def _(cond, lhs, rhs):
     cond = cond.buffer
     rhs = rhs.buffer
     return NDArray(buffer=lib.array_scalar_array_where(cond, lhs, rhs))
+
+
+# cat
+
+
+@primitive.cat_p.register(tuple)
+def _(arrays, dims: tuple[int, ...]):
+    narray = len(arrays)
+    ndim = len(dims)
+    return NDArray(buffer=lib.array_cat([arr.buffer for arr in arrays], narray, dims, ndim))

--- a/arraylib/primitive.py
+++ b/arraylib/primitive.py
@@ -33,7 +33,7 @@ gt_p = bidispatch(_no_impl_error)
 ravel_p = unidispatch(_no_impl_error)
 reshape_p = unidispatch(_no_impl_error)
 transpose_p = unidispatch(_no_impl_error)
-move_axis_p = unidispatch(_no_impl_error)
+move_dim_p = unidispatch(_no_impl_error)
 
 # setter and getter (4)
 get_view_from_range_p = unidispatch(_no_impl_error)
@@ -58,3 +58,8 @@ reduce_p = unidispatch(_no_impl_error)
 # conditional
 
 where_p = ft.partial(bidispatch, lhsnum=1, rhsnum=2)(_no_impl_error)
+
+
+# cat
+
+cat_p = ft.partial(unidispatch)(_no_impl_error)

--- a/arraylib/src/arraylib.c
+++ b/arraylib/src/arraylib.c
@@ -828,7 +828,7 @@ NDArray* array_cat(NDArray** arrays, size_t narray, size_t* dims, size_t ndim) {
         for (size_t j = 0; j < ndim; j++)
             out_shape[dims[j]] += arrays[i]->lay->shape[dims[j]];
 
-    NDArray* dst = array_empty(out_shape, ref_ndim);
+    NDArray* dst = array_zeros(out_shape, ref_ndim);
     FREE(out_shape);
 
     size_t dims_offset[ndim];

--- a/arraylib/src/arraylib.c
+++ b/arraylib/src/arraylib.c
@@ -42,8 +42,8 @@ size_t* size_t_set(size_t* dst, size_t value, size_t size) {
 
 size_t* size_t_copy(size_t* dst, const size_t* src, size_t size) {
     assert(src != NULL && "ValueError: src copy is NULL");
-    memcpy(dst, src, sizeof(size_t) * size);
-    return dst;
+    return memcpy(dst, src, sizeof(size_t) * size);
+    ;
 }
 
 size_t compute_flat_index(const size_t* index, const size_t* stride, size_t ndim) {
@@ -432,7 +432,7 @@ NDArray* array_transpose(NDArray* src, const size_t* dims) {
     return dst;
 }
 
-NDArray* array_move_axis(NDArray* src, const size_t* from, const size_t* to, size_t ndim) {
+NDArray* array_move_dim(NDArray* src, const size_t* from, const size_t* to, size_t ndim) {
     for (size_t i = 0; i < ndim; i++) {
         assert(from[i] >= 0 && from[i] < src->lay->ndim && "ValueError: out of bounds");
         assert(from[i] >= 0 && from[i] < src->lay->ndim && "ValueError: out of bounds");
@@ -442,7 +442,7 @@ NDArray* array_move_axis(NDArray* src, const size_t* from, const size_t* to, siz
     memset(bucket, 0, src->lay->ndim);
 
     for (size_t i = 0; i < ndim; i++)
-        bucket[from[i]] = 1;  // mark used axis
+        bucket[from[i]] = 1;  // mark used dimension
     NDArray* dst = is_contiguous(src) ? array_shallow_copy(src) : array_deep_copy(src);
     size_t to_from[src->lay->ndim];
     size_t_set(to_from, ITERDIM, src->lay->ndim);
@@ -672,7 +672,7 @@ NDArray* array_reduce(
         const size_t* reduce_dims,
         size_t reduce_ndim,
         f32 acc_init) {
-    bool is_reduce_dim[src->lay->ndim];
+    char is_reduce_dim[src->lay->ndim];
     memset(is_reduce_dim, 0, src->lay->ndim);
     for (size_t i = 0; i < reduce_ndim; i++)
         is_reduce_dim[reduce_dims[i]] = 1;
@@ -699,7 +699,7 @@ NDArray* array_reduce(
         while (iter_next(isrc))
             sum = acc_fn(sum, *isrc->ptr);
         isrc->status = ITER_START;
-        array_set_scalar_from_index(dst, sum, idst->index);
+        dst = array_set_scalar_from_index(dst, sum, idst->index);
     }
     FREE(isrc);
     FREE(idst);
@@ -792,5 +792,62 @@ NDArray* array_scalar_scalar_where(NDArray* cond, f32 lhs, f32 rhs) {
 
     FREE(icond);
     FREE(idst);
+    return dst;
+}
+
+// -------------------------------------------------------------------------------------------------
+// JOIN OPERATIONS
+// -------------------------------------------------------------------------------------------------
+
+NDArray* array_cat(NDArray** arrays, size_t narray, size_t* dims, size_t ndim) {
+    // NOTE: concatenation along multiple dimensions is similar to
+    // zero-padded numpy block, for instance an array [[1, 2, 3]] of shape 1x3 and
+    // and array [[1, 2],[3, 4]] of shape 2x2 can be concatenated along the
+    // both axes to form [[1, 2, 3, 0, 0], [0, 0, 0, 1, 2], [0, 0, 0, 3, 4]] of shape 3x5
+    size_t ref_ndim = arrays[0]->lay->ndim;
+    char cat_dim[ref_ndim];
+    memset(cat_dim, 0, ref_ndim);
+
+    for (size_t i = 0; i < ndim; i++) {
+        assert(dims[i] < ref_ndim && "ValueError: concat dimension out of bounds");
+        cat_dim[dims[i]] = 1;
+    }
+
+    for (size_t i = 1; i < narray; i++) {
+        assert(arrays[i]->lay->ndim == ref_ndim && "ValueError: dimension mismatch.");
+        for (size_t j = 0; j < ref_ndim; j++) {
+            if (cat_dim[j] == 1)
+                continue;
+            assert(arrays[i]->lay->shape[j] == arrays[0]->lay->shape[j]
+                   && "ValueError: non-cat dimensions have different values.");
+        }
+    }
+
+    size_t* out_shape = size_t_copy(size_t_alloc(ref_ndim), arrays[0]->lay->shape, ref_ndim);
+    for (size_t i = 1; i < narray; i++)
+        for (size_t j = 0; j < ndim; j++)
+            out_shape[dims[j]] += arrays[i]->lay->shape[dims[j]];
+
+    NDArray* dst = array_empty(out_shape, ref_ndim);
+    FREE(out_shape);
+
+    size_t dims_offset[ndim];
+    size_t_set(dims_offset, 0, ndim);
+
+    for (size_t i = 0; i < narray; i++) {
+        NDIter* isrc = iter_create(arrays[i]->ptr, arrays[i]->lay);
+
+        while (iter_next(isrc)) {
+            size_t temp_index[ref_ndim];
+            size_t_copy(temp_index, isrc->index, ref_ndim);
+            for (size_t j = 0; j < ndim; j++)
+                temp_index[dims[j]] += dims_offset[j];
+            array_set_scalar_from_index(dst, *isrc->ptr, temp_index);
+        }
+        for (size_t j = 0; j < ndim; j++)
+            dims_offset[j] += arrays[i]->lay->shape[dims[j]];
+        FREE(isrc);
+    }
+
     return dst;
 }

--- a/arraylib/src/arraylib.h
+++ b/arraylib/src/arraylib.h
@@ -79,7 +79,6 @@ typedef struct {
     bool view;   /**< Flag indicating if this is a view. */
 } NDArray;
 
-
 typedef struct {
     f32* ptr;      /**< Pointer to the current element. */
     Layout* lay;   /**< Pointer to the memory layout (shape, stride). */
@@ -559,10 +558,10 @@ NDArray* array_transpose(NDArray* array, const size_t* dst);
  * @code
  * size_t src[] = {0, 1};
  * size_t dst[] = {1, 0};
- * NDArray* moved = array_move_axis(array, src, dst, 2); // Swaps the axes
+ * NDArray* moved = array_move_dim(array, src, dst, 2); // Swaps the axes
  * @endcode
  */
-NDArray* array_move_axis(NDArray* array, const size_t* src, const size_t* dst, size_t ndim);
+NDArray* array_move_dim(NDArray* array, const size_t* src, const size_t* dst, size_t ndim);
 
 /**
  * @brief Flattens an NDArray into a 1D array.
@@ -898,7 +897,7 @@ NDArray* array_array_dot(NDArray* lhs, NDArray* rhs);
  *
  * @code
  * size_t axes[] = {0};
- * NDArray* result = array_reduce(add, array, axes, 1, 0.0); // Sums along the first axis
+ * NDArray* result = array_reduce(add, array, axes, 1, 0.0); // Sums along the first dim
  * @endcode
  */
 NDArray* array_reduce(
@@ -916,7 +915,7 @@ NDArray* array_reduce(
  *
  * @code
  * size_t reduce_dims[] = {0};
- * NDArray* result = array_reduce_max(array, reduce_dims, 1); // Finds the max along the first axis
+ * NDArray* result = array_reduce_max(array, reduce_dims, 1); // Finds the max along the first dim
  * @endcode
  */
 NDArray* array_reduce_max(NDArray* array, size_t* reduce_dims, size_t ndim);
@@ -930,7 +929,7 @@ NDArray* array_reduce_max(NDArray* array, size_t* reduce_dims, size_t ndim);
  *
  * @code
  * size_t reduce_dims[] = {0};
- * NDArray* result = array_reduce_min(array, reduce_dims, 1); // Finds the min along the first axis
+ * NDArray* result = array_reduce_min(array, reduce_dims, 1); // Finds the min along the first dim
  * @endcode
  */
 NDArray* array_reduce_min(NDArray* array, size_t* reduce_dims, size_t ndim);
@@ -944,7 +943,7 @@ NDArray* array_reduce_min(NDArray* array, size_t* reduce_dims, size_t ndim);
  *
  * @code
  * size_t reduce_dims[] = {0};
- * NDArray* result = array_reduce_sum(array, reduce_dims, 1); // Sums along the first axis
+ * NDArray* result = array_reduce_sum(array, reduce_dims, 1); // Sums along the first dim
  * @endcode
  */
 NDArray* array_reduce_sum(NDArray* array, size_t* reduce_dims, size_t ndim);
@@ -965,6 +964,12 @@ NDArray* array_array_array_where(NDArray* cond, NDArray* lhs, NDArray* rhs);
 NDArray* array_array_scalar_where(NDArray* cond, NDArray* lhs, f32 rhs);
 NDArray* array_scalar_array_where(NDArray* cond, f32 lhs, NDArray* rhs);
 NDArray* array_scalar_scalar_where(NDArray* cond, f32 lhs, f32 rhs);
+
+// -------------------------------------------------------------------------------------------------
+// JOIN OPERATIONS
+// -------------------------------------------------------------------------------------------------
+
+NDArray* array_cat(NDArray** arrays, size_t narray, size_t* dims, size_t ndim);
 
 // END
 


### PR DESCRIPTION

- for single dimension it is equivalent to`numpy.concatenate`
- for multiple dimensions it is equivalent to zero padded `numpy.block`

```python
import arraylib as al
a = al.reshape(al.arange(1, 1 + 1 * 3), (1, 3))
b = al.reshape(al.arange(1, 1 + 2 * 2), (2, 2))
print(al.cat((a, b), dims=[0, 1]))
```
```
[[1., 2., 3., 0., 0.],
[0., 0., 0., 1., 2.],
[0., 0., 0., 3., 4.]]
```